### PR TITLE
Ajout d'un émetteur et récepteur socket.io

### DIFF
--- a/Assets/Scripts/Network/SocketIO.cs
+++ b/Assets/Scripts/Network/SocketIO.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using Quobject.SocketIoClientDotNet.Client;
@@ -121,17 +121,9 @@ public class SocketIO : MonoBehaviour
         _socket = null;
     }
 
-    public void Emit<T>(string channel, T value) where T : struct
-    {
-        _socket.Emit(channel, value);
-        Debug.Log($"Socket.io: emit '{value}' on '{channel}'");
-    }
-
-    public void Emit(string channel, JObject value)
-    {
-        _socket.Emit(channel, value);
-        Debug.Log($"Socket.io: emit '{value}' on '{channel}'");
-    }
+    public void Emit<T>(string channel, T value) where T : struct => Emit(channel, (object) value);
+    public void Emit(string channel, string value) => Emit(channel, (object) value);
+    public void Emit(string channel, JObject value) => Emit(channel, (object) value);
 
     private void Emit(SportfunCommand command)
     {
@@ -142,6 +134,12 @@ public class SocketIO : MonoBehaviour
             Body = command
         };
         Emit("command", wsPacket);
+    }
+
+    private void Emit(string channel, object value)
+    {
+        _socket.Emit(channel, value);
+        Debug.Log($"Socket.io: emit '{value}' on '{channel}'");        
     }
 
     #endregion

--- a/Assets/Scripts/Network/WebSocketPacket.cs
+++ b/Assets/Scripts/Network/WebSocketPacket.cs
@@ -6,7 +6,7 @@ public class WebSocketPacket
 {
     [JsonProperty("type")] public string Type;
     [JsonProperty("link_id")] public string LinkId;
-    [JsonProperty("body")] public Dictionary<string, string> Body;
+    [JsonProperty("body")] public Dictionary<string, object> Body;
 
     public static implicit operator JObject(WebSocketPacket ws) => JObject.FromObject(ws);
 }


### PR DESCRIPTION
### Émetteur
L'émission peut se faire en utilisant le Network avec le fonction `Emit`.
 - `Emit(string, T)`, prenant comme arguments le nom du channel (*command*, *qr*, ...) et un type valeur (int, float, ...) à envoyer
 - `Emit(string, string)`, prenant comme arguments le nom du channel (*command*, *qr*, ...) et un string à envoyer
 - `Emit(string, JObject)`, prenant comme arguments le nom du channel (*command*, *qr*, ...) et un JObject à envoyer (cela évite d'envoyer un objet non serializé)

### Récepteur
La réception de fait via l'Editeur Unity ; si on veut écouter un channel (`AAA` par exemple), il suffit de rajouter `AAA` dans la liste `Bound Channels`. Pour rajouter un event, il faut le rajouter dans `On Received Event`. Le handler doit être de type `(string, JObject)` correspondant au nom du channel d'où provient l'event et son contenu.
> Attention, tout les handlers reçoivent tous les messages provenant des canaux écoutés ([`Pub/Sub`](https://fr.wikipedia.org/wiki/Publish-subscribe) sur le socket et non sur un channel). Il faut juste le filtrer ensuite (cf. [`InputManager`](https://github.com/sportfun/Games/compare/refactor/socket.io?expand=1#diff-a342faccda5be7bf1d0dec86f9feeea0R31))

---

### **Attention, les scènes n'ont pas été mis à jour**